### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 ### Python
 
 * **[hcloud-python](https://github.com/hetznercloud/hcloud-python) — hcloud-python is a library for the Hetzner Cloud API.**
-* [hetznercloud-py](https://github.com/thlisym/hetznercloud-py) — Python SDK for the new Hetzner cloud
+* [hetznercloud-py](https://github.com/thlisym/hetznercloud-py) — Python SDK for the new Hetzner cloud (**deprecated: please use the official library above**)
 
 ### Ruby
 


### PR DESCRIPTION
Mark 'hetznercloud-py' as deprecated in favor of the official library.